### PR TITLE
Rclone config fix

### DIFF
--- a/yt-backup.py
+++ b/yt-backup.py
@@ -1075,8 +1075,8 @@ def generate_statistics(all_stats=False):
         statistics = "archive_size,videos_monitored,videos_downloaded"
     if "archive_size" in statistics:
         start_time = get_current_timestamp()
-        rclone_size_command = (config["rclone"]["binary_path"] + " size " + repr(config["rclone"]["upload_target"] + ":" + config["rclone"]["upload_base_path"]) + " --json" + \
-                              " --config " + repr(config["rclone"]["config_path"]) if config["rclone"]["config_path"] != "" else "")
+        rclone_size_command = config["rclone"]["binary_path"] + " size " + repr(config["rclone"]["upload_target"] + ":" + config["rclone"]["upload_base_path"]) + " --json" + \
+                              (" --config " + repr(config["rclone"]["config_path"]) if config["rclone"]["config_path"] != "" else "")
 
         logger.debug("rclone size command is: " + rclone_size_command)
         logger.info("Getting rclone size of complete archive dir")

--- a/yt-backup.py
+++ b/yt-backup.py
@@ -1214,8 +1214,9 @@ def rclone_upload():
     set_status("uploading")
     rclone_upload_command = config["rclone"]["binary_path"] + \
                             (" --config " + repr(config["rclone"]["config_path"]) if config["rclone"]["config_path"] != "" else "") + \
-                            config["base"]["download_dir"] + " " + config["rclone"]["upload_target"] + ":" + config["rclone"]["upload_base_path"] + \
-                            " --delete-empty-src-dirs "
+                            (" " + config["rclone"]["move_or_copy"] + " " if config["rclone"]["move_or_copy"] in ("move", "copy") else " move ") + \
+                            repr(config["base"]["download_dir"]) + " " + repr(config["rclone"]["upload_target"] + ":" + config["rclone"]["upload_base_path"]) + \
+                            (" --delete-empty-src-dirs " if config["rclone"]["move_or_copy"] in ("move", "") else "")
 
     logger.debug("rclone upload command is: " + rclone_upload_command)
     logger.info("Uploading files to rclone remote")

--- a/yt-backup.py
+++ b/yt-backup.py
@@ -1075,8 +1075,9 @@ def generate_statistics(all_stats=False):
         statistics = "archive_size,videos_monitored,videos_downloaded"
     if "archive_size" in statistics:
         start_time = get_current_timestamp()
-        rclone_size_command = (" --config " + repr(config["rclone"]["config_path"]) if config["rclone"]["config_path"] != "" else "") + \
-                              config["rclone"]["binary_path"] + " size " + config["rclone"]["upload_target"] + ":" + config["rclone"]["upload_base_path"] + " --json"
+        rclone_size_command = (config["rclone"]["binary_path"] + " size " + repr(config["rclone"]["upload_target"] + ":" + config["rclone"]["upload_base_path"]) + " --json" + \
+                              " --config " + repr(config["rclone"]["config_path"]) if config["rclone"]["config_path"] != "" else "")
+
         logger.debug("rclone size command is: " + rclone_size_command)
         logger.info("Getting rclone size of complete archive dir")
         output = subprocess.run(rclone_size_command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/yt-backup.py
+++ b/yt-backup.py
@@ -1076,6 +1076,8 @@ def generate_statistics(all_stats=False):
     if "archive_size" in statistics:
         start_time = get_current_timestamp()
         rclone_size_command = config["rclone"]["binary_path"] + " size " + config["rclone"]["upload_target"] + ":" + config["rclone"]["upload_base_path"] + " --json"
+        if config["rclone"]["config_path"] != "":
+            rclone_size_command += " --config " + repr(config["rclone"]["config_path"])
         logger.debug("rclone size command is: " + rclone_size_command)
         logger.info("Getting rclone size of complete archive dir")
         output = subprocess.run(rclone_size_command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -1212,6 +1214,8 @@ def rclone_upload():
     start_time = get_current_timestamp()
     set_status("uploading")
     rclone_upload_command = config["rclone"]["binary_path"] + " move " + config["base"]["download_dir"] + " " + config["rclone"]["upload_target"] + ":" + config["rclone"]["upload_base_path"] + " --delete-empty-src-dirs"
+    if config["rclone"]["config_path"] != "":
+        rclone_upload_command += " --config " + repr(config["rclone"]["config_path"])
     logger.debug("rclone upload command is: " + rclone_upload_command)
     logger.info("Uploading files to rclone remote")
     os.system(rclone_upload_command)

--- a/yt-backup.py
+++ b/yt-backup.py
@@ -1075,9 +1075,8 @@ def generate_statistics(all_stats=False):
         statistics = "archive_size,videos_monitored,videos_downloaded"
     if "archive_size" in statistics:
         start_time = get_current_timestamp()
-        rclone_size_command = config["rclone"]["binary_path"] + " size " + config["rclone"]["upload_target"] + ":" + config["rclone"]["upload_base_path"] + " --json"
-        if config["rclone"]["config_path"] != "":
-            rclone_size_command += " --config " + repr(config["rclone"]["config_path"])
+        rclone_size_command = (" --config " + repr(config["rclone"]["config_path"]) if config["rclone"]["config_path"] != "" else "") + \
+                              config["rclone"]["binary_path"] + " size " + config["rclone"]["upload_target"] + ":" + config["rclone"]["upload_base_path"] + " --json"
         logger.debug("rclone size command is: " + rclone_size_command)
         logger.info("Getting rclone size of complete archive dir")
         output = subprocess.run(rclone_size_command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -1213,9 +1212,11 @@ def get_video_resolution(file):
 def rclone_upload():
     start_time = get_current_timestamp()
     set_status("uploading")
-    rclone_upload_command = config["rclone"]["binary_path"] + " move " + config["base"]["download_dir"] + " " + config["rclone"]["upload_target"] + ":" + config["rclone"]["upload_base_path"] + " --delete-empty-src-dirs"
-    if config["rclone"]["config_path"] != "":
-        rclone_upload_command += " --config " + repr(config["rclone"]["config_path"])
+    rclone_upload_command = config["rclone"]["binary_path"] + \
+                            (" --config " + repr(config["rclone"]["config_path"]) if config["rclone"]["config_path"] != "" else "") + \
+                            config["base"]["download_dir"] + " " + config["rclone"]["upload_target"] + ":" + config["rclone"]["upload_base_path"] + \
+                            " --delete-empty-src-dirs "
+
     logger.debug("rclone upload command is: " + rclone_upload_command)
     logger.info("Uploading files to rclone remote")
     os.system(rclone_upload_command)


### PR DESCRIPTION
Hi! First PR here, just fixing couple small bugs with some rclone statements.

+ Fixed rclone commands not using the rclone config location specified in the config.json file.
+ Fixed rclone commands not using the rclone move_or_copy parameter specified in the config.json file.
+ using repr() method to surround file paths with quotations to avoid issues with spaces etc.

Hopefully this covers all the rclone usages.
This assumes that the config_path and move_or_copy keys exist and are strings, with an empty string representing no config. I believe this is how the rest of the project handles the config keys at the moment.

It is a bit of duplicated code and slightly hacky - a possible future improvement to tidy things up could be to have a global rclone object/class that handles everything rclone related.

